### PR TITLE
fix(ci): clean up SWA PR preview environments on close

### DIFF
--- a/.github/workflows/azure-static-web-apps-lemon-hill-0d4d7521e.yml
+++ b/.github/workflows/azure-static-web-apps-lemon-hill-0d4d7521e.yml
@@ -99,19 +99,27 @@ jobs:
           tenant-id: ${{ env.AZURE_TENANT_ID }}
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Get SWA Deployment Token
-        id: swa-token
+      # The Azure/static-web-apps-deploy@v1 "close" action does not work with this
+      # custom OIDC workflow — it returns "No matching static site found" and leaves
+      # each PR's preview environment orphaned (they accumulate toward the SWA
+      # environment cap and eventually block new preview deploys). Delete the
+      # environment directly via the Azure CLI using the OIDC login above. SWA names
+      # each PR's preview environment by the PR number; the existence guard keeps a
+      # PR that never produced a preview from failing this job.
+      - name: Delete PR preview environment
+        env:
+          PR_ENV: ${{ github.event.pull_request.number }}
         run: |
-          TOKEN=$(az staticwebapp secrets list \
-            --name "$SWA_NAME" \
-            --resource-group "$RESOURCE_GROUP" \
-            --query "properties.apiKey" -o tsv)
-          echo "::add-mask::$TOKEN"
-          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
-
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ steps.swa-token.outputs.token }}
-          action: "close"
+          if az staticwebapp environment show \
+               --name "$SWA_NAME" \
+               --resource-group "$RESOURCE_GROUP" \
+               --environment-name "$PR_ENV" >/dev/null 2>&1; then
+            az staticwebapp environment delete \
+              --name "$SWA_NAME" \
+              --resource-group "$RESOURCE_GROUP" \
+              --environment-name "$PR_ENV" \
+              --yes
+            echo "Deleted preview environment $PR_ENV"
+          else
+            echo "No preview environment $PR_ENV to delete"
+          fi


### PR DESCRIPTION
## Problem
The `close_pull_request` job uses `Azure/static-web-apps-deploy@v1` with `action: close`. In this **custom OIDC workflow** that action fails with `The content server has rejected the request with: BadRequest / No matching static site found`, so:
- every PR close has been failing (a CI failure email each time), and
- each PR's **preview environment was never torn down** — they accumulated (PRs #1, #4–#11, #13 were all orphaned) toward the SWA named-environment cap, which would eventually block new PR preview deploys.

The build/deploy job works because it passes `github_id_token`; the `close` action can't resolve the environment through its content-server path here at all.

## Fix
Replace the broken action with a direct **Azure CLI** delete (`az staticwebapp environment delete --environment-name <PR#>`), reusing the OIDC `azure/login` already present in the job. SWA names each PR's preview environment by the PR number. An existence guard (`az ... environment show`) keeps a PR that never produced a preview from failing the job.

Already cleaned up the 10 accumulated orphans manually; `default` (production) is untouched.

## Test Plan
- [x] Workflow YAML validated
- [x] `az staticwebapp environment delete` verified against the live SWA (removed the orphans)
- [ ] On merge: this PR's own close job should run the new step and report "Deleted preview environment" (no failure, no email)

🤖 Generated with [Claude Code](https://claude.com/claude-code)