### PR TITLE
fix(ci): handle fast-merge race in SWA preview cleanup

### DIFF
--- a/.github/workflows/azure-static-web-apps-lemon-hill-0d4d7521e.yml
+++ b/.github/workflows/azure-static-web-apps-lemon-hill-0d4d7521e.yml
@@ -104,22 +104,34 @@ jobs:
       # each PR's preview environment orphaned (they accumulate toward the SWA
       # environment cap and eventually block new preview deploys). Delete the
       # environment directly via the Azure CLI using the OIDC login above. SWA names
-      # each PR's preview environment by the PR number; the existence guard keeps a
-      # PR that never produced a preview from failing this job.
+      # each PR's preview environment by the PR number.
+      #
+      # A preview build can still be in flight when a PR is merged seconds after it
+      # opens, so the environment may not exist yet when this job starts. Poll for
+      # it (deleting as soon as it appears) up to a bounded timeout; if it never
+      # shows, the PR produced no preview and there is nothing to clean up.
       - name: Delete PR preview environment
         env:
           PR_ENV: ${{ github.event.pull_request.number }}
         run: |
-          if az staticwebapp environment show \
-               --name "$SWA_NAME" \
-               --resource-group "$RESOURCE_GROUP" \
-               --environment-name "$PR_ENV" >/dev/null 2>&1; then
-            az staticwebapp environment delete \
-              --name "$SWA_NAME" \
-              --resource-group "$RESOURCE_GROUP" \
-              --environment-name "$PR_ENV" \
-              --yes
-            echo "Deleted preview environment $PR_ENV"
-          else
-            echo "No preview environment $PR_ENV to delete"
-          fi
+          deadline=$((SECONDS + 300))
+          while true; do
+            if az staticwebapp environment show \
+                 --name "$SWA_NAME" \
+                 --resource-group "$RESOURCE_GROUP" \
+                 --environment-name "$PR_ENV" >/dev/null 2>&1; then
+              az staticwebapp environment delete \
+                --name "$SWA_NAME" \
+                --resource-group "$RESOURCE_GROUP" \
+                --environment-name "$PR_ENV" \
+                --yes
+              echo "Deleted preview environment $PR_ENV"
+              break
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "No preview environment $PR_ENV appeared within timeout; nothing to delete"
+              break
+            fi
+            echo "Preview environment $PR_ENV not present yet; waiting…"
+            sleep 20
+          done


### PR DESCRIPTION
## Follow-up to #14
The CLI-based close cleanup from #14 works, but a fast open→merge can race: the preview build may still be in flight when the close job runs, so the single existence check finds nothing and the env is orphaned once the build finishes (observed on #14's own test merge).

## Fix
Poll for the preview environment (delete as soon as it appears) up to a 5-minute bound. Normal merges hit on the first check (no wait); the race resolves within a minute or two; a PR that never produced a preview exits cleanly after the timeout.

## Test Plan
- [x] YAML + `bash -n` validated
- [ ] This PR's own (fast) merge: close job waits if needed and deletes its preview env → SWA back to just `default`

🤖 Generated with [Claude Code](https://claude.com/claude-code)