### PR TITLE
fix(ci): single-check + --no-wait for SWA preview cleanup

### DIFF
--- a/.github/workflows/azure-static-web-apps-lemon-hill-0d4d7521e.yml
+++ b/.github/workflows/azure-static-web-apps-lemon-hill-0d4d7521e.yml
@@ -106,32 +106,33 @@ jobs:
       # environment directly via the Azure CLI using the OIDC login above. SWA names
       # each PR's preview environment by the PR number.
       #
-      # A preview build can still be in flight when a PR is merged seconds after it
-      # opens, so the environment may not exist yet when this job starts. Poll for
-      # it (deleting as soon as it appears) up to a bounded timeout; if it never
-      # shows, the PR produced no preview and there is nothing to clean up.
+      # IMPORTANT — do NOT poll/wait for the environment to appear: when a PR is
+      # merged seconds after opening, its preview build is still in flight, and
+      # deleting the environment mid-build breaks that build. Only act on an
+      # environment that already exists at close time (the normal case — the build
+      # finished long before merge). A fast-merge orphan is rare and harmless.
+      #
+      # Use --no-wait: the deploy identity can issue the delete (it owns the SWA) but
+      # lacks Microsoft.Web/locations/staticSitesOperationStatuses/read to poll the
+      # long-running delete, so fire-and-forget instead of polling (which would error
+      # even though the delete itself succeeds).
       - name: Delete PR preview environment
         env:
           PR_ENV: ${{ github.event.pull_request.number }}
         run: |
-          deadline=$((SECONDS + 300))
-          while true; do
-            if az staticwebapp environment show \
+          if az staticwebapp environment show \
+               --name "$SWA_NAME" \
+               --resource-group "$RESOURCE_GROUP" \
+               --environment-name "$PR_ENV" >/dev/null 2>&1; then
+            if az staticwebapp environment delete \
                  --name "$SWA_NAME" \
                  --resource-group "$RESOURCE_GROUP" \
-                 --environment-name "$PR_ENV" >/dev/null 2>&1; then
-              az staticwebapp environment delete \
-                --name "$SWA_NAME" \
-                --resource-group "$RESOURCE_GROUP" \
-                --environment-name "$PR_ENV" \
-                --yes
-              echo "Deleted preview environment $PR_ENV"
-              break
+                 --environment-name "$PR_ENV" \
+                 --yes --no-wait; then
+              echo "Requested deletion of preview environment $PR_ENV"
+            else
+              echo "::warning::Could not delete preview environment $PR_ENV; clean it up manually."
             fi
-            if [ "$SECONDS" -ge "$deadline" ]; then
-              echo "No preview environment $PR_ENV appeared within timeout; nothing to delete"
-              break
-            fi
-            echo "Preview environment $PR_ENV not present yet; waiting…"
-            sleep 20
-          done
+          else
+            echo "No preview environment $PR_ENV to delete"
+          fi


### PR DESCRIPTION
## Why
The retry from #15 backfired: it waited for the preview env then deleted it **mid-build**, breaking the preview build (`No matching static site build found`). It also surfaced that the deploy identity lacks `Microsoft.Web/locations/staticSitesOperationStatuses/read`, so polling the long-running delete errors — but the delete itself **succeeds** server-side (env 15 was actually removed).

## Fix
- **Single existence check, no polling** — only delete an env that already exists at close time (the normal case; the build finished long before merge). Never wait for an in-flight build → no mid-build race.
- **`--no-wait`** — fire-and-forget the delete so `az` doesn't poll the operation status it can't read. A guarded `::warning::` covers any genuine delete failure without failing the job (no email).

## Test Plan
- [x] YAML + `bash -n` validated
- [ ] Open PR, **wait for preview env to build**, then merge → close job finds the env and requests deletion → SWA returns to just `default`