### PR TITLE
fix(ci): simplify SWA preview cleanup to a clean delete

### DIFF
--- a/.github/workflows/azure-static-web-apps-lemon-hill-0d4d7521e.yml
+++ b/.github/workflows/azure-static-web-apps-lemon-hill-0d4d7521e.yml
@@ -106,49 +106,28 @@ jobs:
       # environment directly via the Azure CLI using the OIDC login above. SWA names
       # each PR's preview environment by the PR number.
       #
-      # Two hard-won constraints baked into the logic below:
+      # Single existence check, NO waiting: when a PR is merged seconds after opening,
+      # its preview build can still be in flight, and deleting the environment
+      # mid-build breaks that build. So only act on an environment that already EXISTS
+      # at close time (the normal case — the build finished long before merge). A
+      # fast-merge orphan is rare and harmless.
       #
-      # 1. Single check, NO waiting. When a PR is merged seconds after opening, its
-      #    preview build is still in flight; deleting the environment mid-build breaks
-      #    that build. So only act on an environment that already EXISTS at close time
-      #    (the normal case — the build finished long before merge). A fast-merge
-      #    orphan is rare and harmless.
-      #
-      # 2. The deploy identity is Contributor on the resource group, which is enough
-      #    to DELETE the environment but NOT to read the delete's long-running-operation
-      #    status (that resource lives at the subscription/location scope, outside the
-      #    RG). So `az ... delete` exits non-zero on the status poll even though the
-      #    delete is accepted. We tolerate that and confirm success by reading the
-      #    environment resource itself (which the identity CAN read), not the op status.
+      # The deploy identity has Reader at the subscription scope so it can poll the
+      # delete's long-running-operation status, so this is a plain, clean delete.
       - name: Delete PR preview environment
         env:
           PR_ENV: ${{ github.event.pull_request.number }}
         run: |
-          if ! az staticwebapp environment show \
-                 --name "$SWA_NAME" \
-                 --resource-group "$RESOURCE_GROUP" \
-                 --environment-name "$PR_ENV" >/dev/null 2>&1; then
+          if az staticwebapp environment show \
+               --name "$SWA_NAME" \
+               --resource-group "$RESOURCE_GROUP" \
+               --environment-name "$PR_ENV" >/dev/null 2>&1; then
+            az staticwebapp environment delete \
+              --name "$SWA_NAME" \
+              --resource-group "$RESOURCE_GROUP" \
+              --environment-name "$PR_ENV" \
+              --yes
+            echo "Deleted preview environment $PR_ENV"
+          else
             echo "No preview environment $PR_ENV to delete"
-            exit 0
           fi
-
-          # Accepted server-side even though az errors polling the op status — tolerate.
-          az staticwebapp environment delete \
-            --name "$SWA_NAME" \
-            --resource-group "$RESOURCE_GROUP" \
-            --environment-name "$PR_ENV" \
-            --yes || true
-
-          # Confirm via the resource itself (readable by this identity).
-          for _ in $(seq 1 12); do
-            if ! az staticwebapp environment show \
-                   --name "$SWA_NAME" \
-                   --resource-group "$RESOURCE_GROUP" \
-                   --environment-name "$PR_ENV" >/dev/null 2>&1; then
-              echo "Deleted preview environment $PR_ENV"
-              exit 0
-            fi
-            sleep 10
-          done
-
-          echo "::warning::Requested deletion of preview environment $PR_ENV but it is still present after ~2m; clean it up manually."


### PR DESCRIPTION
## Context
Follows #17. The deploy service principal now has **Reader at subscription scope**, so it can poll the delete's long-running-operation status (the permission that was missing). That lets us drop the tolerate-error + verify-by-resource scaffolding.

## Change
Plain `az staticwebapp environment delete` behind a single existence check (still no waiting, so we never delete an in-flight preview mid-build). Clean log, no tolerated `AuthorizationFailed` line.

## Test Plan
- [x] YAML + `bash -n` validated
- [ ] Open PR, wait for preview env, merge → close job deletes the env, reports "Deleted preview environment", **no error lines**, SWA back to `default`